### PR TITLE
Deprecate `TomlStreamWriter`, bump dependency versions.

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -37,13 +37,17 @@ kotlin {
     mingwX64()
     macosArm64()
     macosX64()
-    ios()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
     linuxArm64()
     linuxX64()
 
     sourceSets {
         val serializationVersion: String by rootProject
         val datetimeVersion: String by rootProject
+
+        applyDefaultHierarchyTemplate()
 
         all {
             languageSettings {
@@ -107,7 +111,15 @@ kotlin {
             dependsOn(kotlinxMain)
         }
 
-        val iosMain by getting {
+        val iosX64Main by getting {
+            dependsOn(kotlinxMain)
+        }
+
+        val iosArm64Main by getting {
+            dependsOn(kotlinxMain)
+        }
+
+        val iosSimulatorArm64Main by getting {
             dependsOn(kotlinxMain)
         }
 
@@ -171,7 +183,7 @@ tasks {
 }
 
 detekt {
-    config = files("$rootDir/format/detekt.yml")
+    config.from(files("$rootDir/format/detekt.yml"))
 }
 
 afterEvaluate {

--- a/core/src/jvmMain/kotlin/net/peanuuutz/tomlkt/TomlStreamWriter.kt
+++ b/core/src/jvmMain/kotlin/net/peanuuutz/tomlkt/TomlStreamWriter.kt
@@ -18,20 +18,16 @@ package net.peanuuutz.tomlkt
 
 import java.io.OutputStream
 
-/**
- * A [TomlWriter] that writes TOML string to [outputStream].
- *
- * Note that this writer only wraps the stream, so the following requirements
- * should be met:
- * * Pass in a [buffered][OutputStream.buffered] stream. The writer itself won't
- * buffer in any way.
- * * Call [close][OutputStream.close] when finished, or use [AutoCloseable.use]
- * for short.
- *
- * Use with [Toml.encodeToWriter] to encode objects. This is useful for
- * concatenating two TOML streams. However, programmer should prefer
- * [Toml.encodeToStream] if only one object is being encoded.
- */
+@Deprecated(
+    message = "This writer is expensive. Please use TomlNativeWriter instead.",
+    replaceWith = ReplaceWith(
+        expression = "TomlNativeWriter(outputStream.writer())",
+        imports = [
+            "net.peanuuutz.tomlkt.TomlNativeWriter",
+            "kotlin.io.path.writer"
+        ]
+    )
+)
 public class TomlStreamWriter(
     private val outputStream: OutputStream
 ) : AbstractTomlWriter() {

--- a/core/src/jvmMain/kotlin/net/peanuuutz/tomlkt/TomlStreams.kt
+++ b/core/src/jvmMain/kotlin/net/peanuuutz/tomlkt/TomlStreams.kt
@@ -26,16 +26,16 @@ import java.io.OutputStream
 import java.io.Reader
 import java.io.Writer
 
-/**
- * Serializes [value] into [outputStream] using [serializer].
- *
- * Note that when finished, `outputStream` is automatically
- * [closed][OutputStream.close].
- *
- * @throws TomlEncodingException if `value` cannot be serialized.
- *
- * @see TomlStreamWriter
- */
+@Deprecated(
+    message = "This method is expensive. Please use encodeToNativeWriter instead.",
+    replaceWith = ReplaceWith(
+        expression = "encodeToNativeWriter(serializer, value, outputStream.writer())",
+        imports = [
+            "net.peanuuutz.tomlkt.encodeToNativeWriter",
+            "kotlin.io.path.writer"
+        ]
+    )
+)
 public fun <T> Toml.encodeToStream(
     serializer: SerializationStrategy<T>,
     value: T,
@@ -47,17 +47,16 @@ public fun <T> Toml.encodeToStream(
     }
 }
 
-/**
- * Serializes [value] into [outputStream] using the serializer retrieved from
- * reified type parameter.
- *
- * Note that when finished, `outputStream` is automatically
- * [closed][OutputStream.close].
- *
- * @throws TomlEncodingException if `value` cannot be serialized.
- *
- * @see TomlStreamWriter
- */
+@Deprecated(
+    message = "This method is expensive. Please use encodeToNativeWriter instead.",
+    replaceWith = ReplaceWith(
+        expression = "encodeToNativeWriter(value, outputStream.writer())",
+        imports = [
+            "net.peanuuutz.tomlkt.encodeToNativeWriter",
+            "kotlin.io.path.writer"
+        ]
+    )
+)
 public inline fun <reified T> Toml.encodeToStream(
     value: T,
     outputStream: OutputStream

--- a/core/src/jvmTest/kotlin/net/peanuuutz/tomlkt/StreamTest.kt
+++ b/core/src/jvmTest/kotlin/net/peanuuutz/tomlkt/StreamTest.kt
@@ -2,7 +2,6 @@ package net.peanuuutz.tomlkt
 
 import kotlinx.serialization.Serializable
 import kotlin.io.path.Path
-import kotlin.io.path.outputStream
 import kotlin.io.path.readText
 import kotlin.io.path.reader
 import kotlin.io.path.writeText
@@ -44,15 +43,6 @@ class StreamTest {
     """.trimIndent()
 
     val p1 = Path("build/config.toml")
-
-    @Test
-    fun encodeToStream() {
-        Toml.encodeToStream(M1.serializer(), m11, p1.outputStream())
-
-        val r = p1.readText()
-
-        assertEquals(s11, r)
-    }
 
     @Test
     fun encodeToNativeWriter() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,16 +11,16 @@ kotlin.js.generate.executable.default = false
 
 group = net.peanuuutz.tomlkt
 archivesName = tomlkt
-version = 0.3.7
+version = 0.3.8
 
 # Dependencies
 
-kotlinVersion = 1.9.0
+kotlinVersion = 1.9.20
 
-serializationVersion = 1.6.0
-datetimeVersion = 0.4.1
+serializationVersion = 1.6.2
+datetimeVersion = 0.5.0
 
-detektVersion = 1.22.0
+detektVersion = 1.23.4
 jmhVersion = 0.7.1
 
-dokkaVersion = 1.8.20
+dokkaVersion = 1.9.10


### PR DESCRIPTION
Resolve #63.

_Note: 0.3.8 will be waiting till Kotlin 2.0 comes out._