### PR TITLE
fix: parse nested arrays of tables with repeated path segments

### DIFF
--- a/core/src/commonMain/kotlin/dev/eav/tomlkt/internal/parser/TomlElementParser.kt
+++ b/core/src/commonMain/kotlin/dev/eav/tomlkt/internal/parser/TomlElementParser.kt
@@ -185,7 +185,7 @@ internal class TomlElementParser(
                     } else {
                         val iterator = arrayOfTableIndices.keys.iterator()
                         for (key in iterator) {
-                            if (key != path && key.containsAll(path)) {
+                            if (key.size > path.size && key.subList(0, path.size) == path) {
                                 iterator.remove()
                             }
                         }

--- a/core/src/commonTest/kotlin/dev/eav/tomlkt/ArrayOfTableTest.kt
+++ b/core/src/commonTest/kotlin/dev/eav/tomlkt/ArrayOfTableTest.kt
@@ -417,4 +417,45 @@ class ArrayOfTableTest {
     fun decodeEmptyCollectionLikeWithMapLikeElementUnsorted() {
         testDecode(M6.serializer(), s65, m63)
     }
+
+    @Serializable
+    data class NestedArrayRoot(
+        val hooks: HookConfiguration
+    )
+
+    @Serializable
+    data class HookConfiguration(
+        val stop: List<StopHook>
+    )
+
+    @Serializable
+    data class StopHook(
+        val hooks: List<CommandHook>
+    )
+
+    @Serializable
+    data class CommandHook(
+        val command: String
+    )
+
+    @Test
+    fun decodeNestedArrayOfTablesWithRepeatedPathSegment() {
+        val source = """
+            [[hooks.stop]]
+
+            [[hooks.stop.hooks]]
+            command = "notify"
+        """.trimIndent()
+        val expected = NestedArrayRoot(
+            hooks = HookConfiguration(
+                stop = listOf(
+                    StopHook(
+                        hooks = listOf(CommandHook(command = "notify"))
+                    )
+                )
+            )
+        )
+
+        testDecode(NestedArrayRoot.serializer(), source, expected)
+    }
 }


### PR DESCRIPTION
I'm using this library to parse the Codex `config.toml`. It crashed on such file:

```toml
[[hooks.Stop]]

[[hooks.Stop.hooks]]
type = "command"
command = "/home/stream/.local/bin/codex-notify"
timeout = 10
```

This happens on the latest main branch(70a75c2) and the latest release.
```stacktrace
java.lang.NullPointerException
    at dev.eav.tomlkt.internal.parser.TreeNodeKt.addByPathRecursively(TreeNode.kt:120)
    at dev.eav.tomlkt.internal.parser.TreeNodeKt.addByPath(TreeNode.kt:80)
    at dev.eav.tomlkt.internal.parser.TomlElementParser.parse(TomlElementParser.kt:197)
    at dev.eav.tomlkt.Toml.parseToTomlTable(Toml.kt:258)
    at dev.eav.tomlkt.Toml.parseToTomlTable(Toml.kt:247)
```

So I fixed this issue in this PR.